### PR TITLE
Fix p5.createloop library

### DIFF
--- a/p5-analysis/src/models/libraries/community-libraries.json
+++ b/p5-analysis/src/models/libraries/community-libraries.json
@@ -80,7 +80,7 @@
     "packageName": "createloop",
     "importPath": "https://unpkg.com/p5.createloop@0.2.8/dist/p5.createloop.js",
     "defines": {
-      "globals": ["createloop"]
+      "globals": ["createLoop"]
     }
   },
   {


### PR DESCRIPTION
Fix typo in the definition of globals for the p5.createloop community library